### PR TITLE
Fix dark grey background gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div class="background">
+    <div class="blob"></div>
+    <div class="blob"></div>
+    <div class="blob"></div>
+  </div>
   <header>
     <div class="logo"><strong>Dakota Research</strong></div>
     <nav>

--- a/style.css
+++ b/style.css
@@ -55,3 +55,65 @@ footer {
     background-color: #f5f5f7;
     color: #555;
 }
+
+/* Animated blurry gradient background */
+.background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.background .blob {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.7), rgba(50, 50, 50, 0.7));
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.8;
+    animation-duration: 40s;
+    animation-timing-function: ease-in-out;
+    animation-iteration-count: infinite;
+    animation-direction: alternate;
+}
+
+.background .blob:nth-child(1) {
+    top: 10%;
+    left: 20%;
+    animation-name: blob1;
+}
+
+.background .blob:nth-child(2) {
+    top: 50%;
+    left: 60%;
+    animation-name: blob2;
+}
+
+.background .blob:nth-child(3) {
+    top: 80%;
+    left: 30%;
+    animation-name: blob3;
+}
+
+@keyframes blob1 {
+    0% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(30vw, -20vh) scale(1.2); }
+    100% { transform: translate(0, 0) scale(1); }
+}
+
+@keyframes blob2 {
+    0% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(-25vw, -15vh) scale(1.3); }
+    100% { transform: translate(0, 0) scale(1); }
+}
+
+@keyframes blob3 {
+    0% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(15vw, 25vh) scale(1.1); }
+    100% { transform: translate(0, 0) scale(1); }
+}


### PR DESCRIPTION
## Summary
- ensure gradient uses dark grey and white hues
- keep background container above page background via `z-index: 0`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68536ebc821c8331a3e218b87b32d5b2