### PR TITLE
Add architect portfolio layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,30 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Dakota Research</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ethan Ranalli - Architect</title>
+  <link rel="stylesheet" href="ranalli.css">
 </head>
 <body>
-  <div class="background">
-    <div class="blob"></div>
-    <div class="blob"></div>
-    <div class="blob"></div>
-  </div>
   <header>
-    <div class="logo"><strong>Dakota Research</strong></div>
-    <nav>
-      <a href="index.html">Home</a>
-      <a href="about.html">About</a>
-      <a href="contact.html">Contact</a>
-    </nav>
+    <div class="container">
+      <div class="site-name">Ethan Ranalli</div>
+      <nav>
+        <a href="#">Home</a>
+        <a href="#">About</a>
+        <a href="#">Projects</a>
+        <a href="#">Resume</a>
+        <a href="#">Contact</a>
+      </nav>
+    </div>
   </header>
 
-  <main class="parallax">
-    <h1>Research for a changing world.</h1>
-    <p>At Dakota Research, we provide innovative insights to tackle global challenges and drive progress.</p>
-    <a href="about.html" class="btn">Learn more</a>
-  </main>
+  <section class="hero">
+    <h1>Designing spaces that inspire</h1>
+    <p>Architectural solutions that balance creativity and function</p>
+  </section>
 </body>
 </html>

--- a/ranalli.css
+++ b/ranalli.css
@@ -1,0 +1,60 @@
+body {
+  margin: 0;
+  padding-top: 70px; /* space for fixed header */
+  font-family: Helvetica, Arial, sans-serif;
+  background: #fff;
+  color: #000;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  z-index: 1000;
+}
+
+header .container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 15px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.site-name {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+
+nav a {
+  margin-left: 20px;
+  text-decoration: none;
+  color: #000;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+.hero {
+  height: 80vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 0 20px;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+}
+
+.hero p {
+  font-size: 1.25rem;
+  max-width: 600px;
+}

--- a/research_index.html
+++ b/research_index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Dakota Research</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="background">
+    <div class="blob"></div>
+    <div class="blob"></div>
+    <div class="blob"></div>
+  </div>
+  <header>
+    <div class="logo"><strong>Dakota Research</strong></div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+
+  <main class="parallax">
+    <h1>Research for a changing world.</h1>
+    <p>At Dakota Research, we provide innovative insights to tackle global challenges and drive progress.</p>
+    <a href="about.html" class="btn">Learn more</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Ethan Ranalli architect portfolio homepage
- create minimalist CSS for portfolio
- keep previous homepage as `research_index.html`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6855725125e08331a0aa95437eaf1b1f