### PR TITLE
Simplify background and add mobile styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,6 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="background">
-    <div class="blob"></div>
-    <div class="blob"></div>
-    <div class="blob"></div>
-  </div>
   <header>
     <div class="logo"><strong>Dakota Research</strong></div>
     <nav>

--- a/style.css
+++ b/style.css
@@ -71,67 +71,6 @@ footer {
     color: #555;
 }
 
-/* Animated blurry gradient background */
-.background {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    pointer-events: none;
-    z-index: -1;
-}
-
-.background .blob {
-    position: absolute;
-    width: 300px;
-    height: 300px;
-    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.7), rgba(50, 50, 50, 0.7));
-    border-radius: 50%;
-    filter: blur(80px);
-    opacity: 0.8;
-    animation-duration: 40s;
-    animation-timing-function: ease-in-out;
-    animation-iteration-count: infinite;
-    animation-direction: alternate;
-}
-
-.background .blob:nth-child(1) {
-    top: 10%;
-    left: 20%;
-    animation-name: blob1;
-}
-
-.background .blob:nth-child(2) {
-    top: 50%;
-    left: 60%;
-    animation-name: blob2;
-}
-
-.background .blob:nth-child(3) {
-    top: 80%;
-    left: 30%;
-    animation-name: blob3;
-}
-
-@keyframes blob1 {
-    0% { transform: translate(0, 0) scale(1); }
-    50% { transform: translate(30vw, -20vh) scale(1.2); }
-    100% { transform: translate(0, 0) scale(1); }
-}
-
-@keyframes blob2 {
-    0% { transform: translate(0, 0) scale(1); }
-    50% { transform: translate(-25vw, -15vh) scale(1.3); }
-    100% { transform: translate(0, 0) scale(1); }
-}
-
-@keyframes blob3 {
-    0% { transform: translate(0, 0) scale(1); }
-    50% { transform: translate(15vw, 25vh) scale(1.1); }
-    100% { transform: translate(0, 0) scale(1); }
-}
 
 /* Parallax effect */
 .parallax {
@@ -158,4 +97,24 @@ main.parallax {
 
 .parallax a {
     color: #0071e3;
+}
+
+@media (max-width: 600px) {
+    nav {
+        flex-direction: column;
+        align-items: center;
+    }
+    nav a {
+        margin: 10px 0;
+    }
+    header {
+        padding: 40px 20px;
+    }
+    header h1 {
+        font-size: 2rem;
+    }
+    main {
+        padding: 0 20px;
+        font-size: 1rem;
+    }
 }


### PR DESCRIPTION
## Summary
- remove gradient background markup from homepage
- delete gradient blob CSS
- add responsive layout rules for small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68557ce45fa08331b0fb40b1e6ea08a0